### PR TITLE
curl SSL オプション指定対応

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(serial 6.2.0)
 set(soserial 6)
 
 set(LIB_SOURCE_FILES
+    src/nb_http_options.cc
     src/nb_http_response.cc
     src/nb_json_array.cc
     src/nb_json_object.cc

--- a/functional_tests/CMakeLists.txt
+++ b/functional_tests/CMakeLists.txt
@@ -33,6 +33,7 @@ set(TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/nb_file_bucket_ft.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/nb_file_bucket_ft_m.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/nb_api_gateway_ft.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/nb_http_options_ft.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/durbility_ft.cc
     )
 

--- a/functional_tests/ft_data.cc
+++ b/functional_tests/ft_data.cc
@@ -55,4 +55,25 @@ const std::string kNoAclObjectBucketName = "noAclObjectBucket";
 
 // 空文字
 const std::string kEmpty = "";
+
+namespace ssl {
+// SSL認証評価用エンドポイント
+// クライアント認証を設定したサーバ
+const std::string kEndPointUrl = "https://XX.XX.XX.XX/api";
+
+const std::string kTenantId = "";
+const std::string kAppId = "";
+const std::string kAppKey = "";
+const std::string kMasterKey = "";
+const std::string kProxy = "";
+
+// 認証に必要なファイルはあらかじめ files 配下に配置する
+const std::string kSslCertFile = "client_auth/cert.pem";
+const std::string kSslKeyFile = "client_auth/key.pem";
+// 以下でハッシュ化した名前をつける
+// openssl x509 -hash -noout -in cacert.pem
+const std::string kSslCaCertFile = "server_auth/XXXXXXX.0";
+const std::string kSslCaCertDir = "server_auth";
+}
+
 } //namespace necbaas

--- a/functional_tests/ft_data.h
+++ b/functional_tests/ft_data.h
@@ -61,5 +61,21 @@ extern const std::string kNoAclObjectBucketName;
 
 // 空文字
 extern const std::string kEmpty;
+
+namespace ssl {
+extern const std::string kEndPointUrl;
+
+extern const std::string kTenantId;
+extern const std::string kAppId;
+extern const std::string kAppKey;
+extern const std::string kMasterKey;
+extern const std::string kProxy;
+
+extern const std::string kSslCertFile;
+extern const std::string kSslKeyFile;
+extern const std::string kSslCaCertFile;
+extern const std::string kSslCaCertDir;
+} //namespace ssl
+
 } //namespace necbaas
 #endif //NECBAAS_FTDATA_H

--- a/functional_tests/nb_http_options_ft.cc
+++ b/functional_tests/nb_http_options_ft.cc
@@ -1,0 +1,118 @@
+#include "gtest/gtest.h"
+#include "ft_data.h"
+#include "ft_util.h"
+#include "necbaas/nb_user.h"
+
+using std::string;
+using std::vector;
+using std::shared_ptr;
+
+namespace necbaas {
+
+namespace FTUtil {
+string CreateUser(shared_ptr<NbService> service, const string &user_name, const string &email, const string &password, const NbJsonObject &options);
+void CreateGroup(shared_ptr<NbService> service, const string &group);
+void UpdateGroup(shared_ptr<NbService> service, const string &group, const NbJsonObject &user_list);
+}
+
+namespace ssl {
+
+class NbHttpOptionsFT : public ::testing::Test {
+  protected:
+    static void SetUpTestCase() {
+        NbJsonObject users;
+        NbJsonArray user_list;
+        auto master_service = NbService::CreateService(kEndPointUrl, kTenantId, kAppId, kAppKey, kProxy);
+        master_service->SetHttpOptions(NbHttpOptions()
+                                           .SslVerifyPeer(false)
+                                           .SslCert(FTUtil::MakeFilePath(kSslCertFile))
+                                           .SslKey(FTUtil::MakeFilePath(kSslKeyFile)));
+
+        user_list.Append(FTUtil::CreateUser(master_service, kUserName, kEmail, kPassword, kOptions));
+        users.PutJsonArray("users", user_list);
+        FTUtil::CreateGroup(master_service, "group1");
+        FTUtil::UpdateGroup(master_service, "group1", users);
+    }
+    static void TearDownTestCase() {}
+
+    virtual void SetUp() {}
+    virtual void TearDown() {}
+};
+
+TEST_F(NbHttpOptionsFT, ClientAuthSslTest) {
+    shared_ptr<NbService> service = NbService::CreateService(kEndPointUrl, kTenantId, kAppId, kAppKey, kProxy);
+    service->SetHttpOptions(NbHttpOptions()
+        .SslVerifyPeer(false)
+        .SslCert(FTUtil::MakeFilePath(kSslCertFile))
+        .SslKey(FTUtil::MakeFilePath(kSslKeyFile)));
+
+    NbResult<NbUser> result = NbUser::LoginWithUsername(service, kUserName, kPassword);
+    // 通信成功でＯＫとする
+    ASSERT_TRUE(result.IsSuccess());
+    NbUser::Logout(service);
+}
+
+TEST_F(NbHttpOptionsFT, ClientAuthWrongCertTypeSslTest) {
+    shared_ptr<NbService> service = NbService::CreateService(kEndPointUrl, kTenantId, kAppId, kAppKey, kProxy);
+    service->SetHttpOptions(NbHttpOptions()
+                                .SslVerifyPeer(false)
+                                .SslCert(FTUtil::MakeFilePath(kSslCertFile))
+                                .SslKey(FTUtil::MakeFilePath(kSslKeyFile))
+                                .SslCertType("DER"));
+
+    NbResult<NbUser> result = NbUser::LoginWithUsername(service, kUserName, kPassword);
+    ASSERT_FALSE(result.IsSuccess());
+    NbUser::Logout(service);
+}
+
+TEST_F(NbHttpOptionsFT, VerifyPeerSslTest) {
+    shared_ptr<NbService> service = NbService::CreateService(kEndPointUrl, kTenantId, kAppId, kAppKey, kProxy);
+    service->SetHttpOptions(NbHttpOptions()
+                                .SslVerifyPeer(false)
+                                .SslCert(FTUtil::MakeFilePath(kSslCertFile))
+                                .SslKey(FTUtil::MakeFilePath(kSslKeyFile)));
+
+    NbResult<NbUser> result = NbUser::LoginWithUsername(service, kUserName, kPassword);
+    ASSERT_TRUE(result.IsSuccess());
+    NbUser::Logout(service);
+
+    service = NbService::CreateService(kEndPointUrl, kTenantId, kAppId, kAppKey, kProxy);
+    service->SetHttpOptions(NbHttpOptions()
+                                .SslVerifyPeer(true)
+                                .SslCert(FTUtil::MakeFilePath(kSslCertFile))
+                                .SslKey(FTUtil::MakeFilePath(kSslKeyFile)));
+    result = NbUser::LoginWithUsername(service, kUserName, kPassword);
+    ASSERT_FALSE(result.IsSuccess());
+    NbUser::Logout(service);
+}
+
+TEST_F(NbHttpOptionsFT, CaInfoSslTest) {
+    shared_ptr<NbService> service = NbService::CreateService(kEndPointUrl, kTenantId, kAppId, kAppKey, kProxy);
+    service->SetHttpOptions(NbHttpOptions()
+                                .SslVerifyPeer(true)
+                                .CaInfo(FTUtil::MakeFilePath(kSslCaCertFile))
+                                .SslCert(FTUtil::MakeFilePath(kSslCertFile))
+                                .SslKey(FTUtil::MakeFilePath(kSslKeyFile)));
+
+    NbResult<NbUser> result = NbUser::LoginWithUsername(service, kUserName, kPassword);
+    // 通信成功でＯＫとする
+    ASSERT_TRUE(result.IsSuccess());
+    NbUser::Logout(service);
+}
+
+TEST_F(NbHttpOptionsFT, CaPathSslTest) {
+    shared_ptr<NbService> service = NbService::CreateService(kEndPointUrl, kTenantId, kAppId, kAppKey, kProxy);
+    service->SetHttpOptions(NbHttpOptions()
+                                .SslVerifyPeer(true)
+                                .CaPath(FTUtil::MakeFilePath(kSslCaCertDir))
+                                .SslCert(FTUtil::MakeFilePath(kSslCertFile))
+                                .SslKey(FTUtil::MakeFilePath(kSslKeyFile)));
+
+    NbResult<NbUser> result = NbUser::LoginWithUsername(service, kUserName, kPassword);
+    // 通信成功でＯＫとする
+    ASSERT_TRUE(result.IsSuccess());
+    NbUser::Logout(service);
+}
+
+} //namespace ssl
+} //namespace necbaas

--- a/include/necbaas/internal/nb_http_request.h
+++ b/include/necbaas/internal/nb_http_request.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 NEC Corporation
+ * Copyright (C) 2017-2019 NEC Corporation
  */
 
 #ifndef NECBAAS_NBHTTPREQUEST_H
@@ -9,6 +9,7 @@
 #include <list>
 #include "necbaas/nb_http_request_method.h"
 #include "necbaas/nb_result_code.h"
+#include "necbaas/nb_http_options.h"
 
 namespace necbaas {
 
@@ -30,7 +31,7 @@ class NbHttpRequest {
      */
     NbHttpRequest(const std::string &url, const NbHttpRequestMethod &method,
                   const std::list<std::string> &headers, const std::string &body,
-                  const std::string &proxy);
+                  const std::string &proxy, const NbHttpOptions &http_options);
 
     /**
      * デストラクタ.
@@ -68,6 +69,12 @@ class NbHttpRequest {
     const std::string &GetProxy() const;
 
     /**
+     * CURLオプション取得.
+     * @return      Curlオプション
+     */
+    std::list<std::shared_ptr<curlpp::OptionBase>> GetHttpOptions() const;
+
+    /**
      * ダンプ.
      * ログにHTTPリクエスト情報を出力する
      */
@@ -78,6 +85,7 @@ class NbHttpRequest {
     const std::list<std::string> headers_{};    /*!< HTTPヘッダリスト */
     const std::string body_{};                  /*!< HTTPボディ       */
     const std::string proxy_{};                 /*!< Proxy URL        */
+    const NbHttpOptions http_options_{};        /*!< HTTPオプション   */
 };
 } //namespace necbaas
 

--- a/include/necbaas/internal/nb_http_request_factory.h
+++ b/include/necbaas/internal/nb_http_request_factory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 NEC Corporation
+ * Copyright (C) 2017-2019 NEC Corporation
  */
 
 #ifndef NECBAAS_NBHTTPREQUESTFACTORY_H
@@ -9,6 +9,7 @@
 #include <map>
 #include "necbaas/nb_http_request_method.h"
 #include "necbaas/internal/nb_http_request.h"
+#include "necbaas/nb_http_options.h"
 
 namespace necbaas {
 
@@ -35,7 +36,8 @@ class NbHttpRequestFactory {
      * @param[in]   sessnon_token       セッショントークン
      */
     NbHttpRequestFactory(const std::string &end_point_url, const std::string &tenant_id, const std::string &app_id,
-                         const std::string &app_key, const std::string &sessnon_token, const std::string &proxy);
+                         const std::string &app_key, const std::string &sessnon_token, const std::string &proxy,
+                         const NbHttpOptions &http_options);
 
     /**
      * デストラクタ.
@@ -147,6 +149,7 @@ class NbHttpRequestFactory {
     const std::string app_key_;                                 /*!< アプリケーションキー */
     const std::string session_token_;                           /*!< セッショントークン */
     const std::string proxy_;                                   /*!< Proxy */
+    const NbHttpOptions http_options_;                          /*!< HTTPオプション */
 
     NbHttpRequestMethod request_method_{NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET};
                                                                 /*!< HTTPメソッド */

--- a/include/necbaas/nb_http_options.h
+++ b/include/necbaas/nb_http_options.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 NEC Corporation
+ */
+
+#ifndef NECBAAS_NBHTTPOPTIONS_H
+#define NECBAAS_NBHTTPOPTIONS_H
+
+#include <string>
+#include <map>
+#include <memory>
+#include <curlpp/OptionBase.hpp>
+
+namespace necbaas {
+
+/**
+ * @class NbHttpOptions nb_http_options.h "necbaas/nb_http_options.h"
+ * HTTPオプション.
+ *
+ * <b>本クラスのインスタンスはスレッドセーフではない</b>
+ */
+class NbHttpOptions {
+    // ユーザにCURLオプションは露出せずNbHttpRequstのみにアクセスを許す
+    friend class NbHttpRequest;
+    friend class TestUtil;
+
+public:
+
+	/**
+     * SET CURLオプション.
+     */
+
+    NbHttpOptions &SslCert(const std::string &);
+    NbHttpOptions &SslCertType(const std::string &);
+    NbHttpOptions &SslCertPasswd(const std::string &);
+    NbHttpOptions &SslKey(const std::string &);
+    NbHttpOptions &SslKeyType(const std::string &);
+    NbHttpOptions &SslKeyPasswd(const std::string &);
+    NbHttpOptions &SslVerifyPeer(bool);
+    NbHttpOptions &CaInfo(const std::string &);
+    NbHttpOptions &CaPath(const std::string &);
+
+private:
+    typedef std::map<CURLoption, std::shared_ptr<curlpp::OptionBase>> options;
+
+    options GetOptions() const;
+    options options_;
+};
+
+}  // namespace necbaas
+#endif  // NECBAAS_NBHTTPOPTIONS_H

--- a/include/necbaas/nb_service.h
+++ b/include/necbaas/nb_service.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 NEC Corporation
+ * Copyright (C) 2017-2019 NEC Corporation
  */
 
 #ifndef NECBAAS_NBSERVICE_H
@@ -121,6 +121,12 @@ class NbService {
     void ClearSessionToken();
 
     /**
+     * HTTPアクセスのオプション設定.
+     * @param[in]   options    HTTPオプション
+     */
+    void SetHttpOptions(const NbHttpOptions &options);
+
+    /**
      * <b>[内部処理用]</b>
      * @internal
      * <p>REST実行(データの送受信).</p>
@@ -159,6 +165,7 @@ class NbService {
     std::string endpoint_url_;              /*!< Endpoint URI */
     std::string tenant_id_;                 /*!< テナントID */
     std::string proxy_;                     /*!< Proxy URL */
+    NbHttpOptions http_options_;            /*!< HTTPオプション */
     NbSessionToken session_token_;          /*!< セッショントークン */
     NbRestExecutorPool rest_executor_pool_; /*!< REST Executorプール */
     std::mutex session_token_mutex_;        /*!< セッショントークン更新用Mutex */

--- a/src/internal/nb_http_request.cc
+++ b/src/internal/nb_http_request.cc
@@ -1,10 +1,11 @@
 /*
- * Copyright (C) 2017 NEC Corporation
+ * Copyright (C) 2017-2019 NEC Corporation
  */
 
 #include "necbaas/internal/nb_http_request.h"
 #include "necbaas/internal/nb_logger.h"
 #include "necbaas/internal/nb_constants.h"
+#include "necbaas/nb_http_options.h"
 
 namespace necbaas {
 
@@ -13,8 +14,8 @@ using std::list;
 using std::vector;
 
 NbHttpRequest::NbHttpRequest(const string &url, const NbHttpRequestMethod &method, const list<string> &headers,
-                             const string &body, const string &proxy)
-    : url_(url), method_(method), headers_(headers), body_(body), proxy_(proxy) {}
+                             const string &body, const string &proxy, const NbHttpOptions &http_options)
+    : url_(url), method_(method), headers_(headers), body_(body), proxy_(proxy), http_options_(http_options) {}
 
 NbHttpRequest::~NbHttpRequest() {}
 
@@ -27,6 +28,14 @@ const list<string> &NbHttpRequest::GetHeaders() const { return headers_; }
 const string &NbHttpRequest::GetBody() const { return body_; }
 
 const string &NbHttpRequest::GetProxy() const { return proxy_; }
+
+std::list<std::shared_ptr<curlpp::OptionBase>> NbHttpRequest::GetHttpOptions() const {
+    std::list<std::shared_ptr<curlpp::OptionBase>> options;
+    for (const auto &pair: http_options_.GetOptions()) {
+        options.push_back(pair.second);
+    }
+    return options;
+}
 
 void NbHttpRequest::Dump() const {
     if (!NbLogger::IsRestLogEnabled()) {

--- a/src/internal/nb_http_request_factory.cc
+++ b/src/internal/nb_http_request_factory.cc
@@ -1,11 +1,12 @@
 /*
- * Copyright (C) 2017 NEC Corporation
+ * Copyright (C) 2017-2019 NEC Corporation
  */
 
 #include "necbaas/internal/nb_http_request_factory.h"
 #include <curlpp/cURLpp.hpp>
 #include "necbaas/internal/nb_constants.h"
 #include "necbaas/internal/nb_logger.h"
+#include "necbaas/nb_http_options.h"
 
 namespace necbaas {
 
@@ -14,13 +15,15 @@ using std::list;
 using std::multimap;
 
 NbHttpRequestFactory::NbHttpRequestFactory(const string &end_point_url, const string &tenant_id, const string &app_id,
-                                           const string &app_key, const string &session_token, const string &proxy)
+                                           const string &app_key, const string &session_token, const string &proxy,
+                                           const NbHttpOptions &http_options)
     : end_point_url_(end_point_url),
       tenant_id_(tenant_id),
       app_id_(app_id),
       app_key_(app_key),
       session_token_(session_token),
-      proxy_(proxy) {
+      proxy_(proxy),
+      http_options_(http_options) {
     CheckParameter();
 }
 
@@ -118,7 +121,7 @@ NbHttpRequest NbHttpRequestFactory::Build() {
         }
     }
 
-    return NbHttpRequest(url, request_method_, header_list, body_, proxy_);
+    return NbHttpRequest(url, request_method_, header_list, body_, proxy_, http_options_);
 }
 
 NbResultCode NbHttpRequestFactory::GetError() const { return error_; }

--- a/src/internal/nb_rest_executor.cc
+++ b/src/internal/nb_rest_executor.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 NEC Corporation
+ * Copyright (C) 2017-2019 NEC Corporation
  */
 
 #include "necbaas/internal/nb_rest_executor.h"
@@ -248,6 +248,11 @@ void NbRestExecutor::SetOptCommon(const NbHttpRequest &request, NbHttpHandler &h
     // Proxy設定
     // 空文字でも設定する(明示的にProxy未使用)
     curlpp_easy_.setOpt(new curlpp::Options::Proxy(request.GetProxy()));
+
+    // CURLオプション設定
+    for (const auto &opt: request.GetHttpOptions()) {
+        curlpp_easy_.setOpt(opt->clone());
+    }
 
     // タイムアウト設定
     curlpp_easy_.setOpt(new curlpp::Options::Timeout(timeout < 0 ? kRestTimeoutDefault : timeout));

--- a/src/nb_http_options.cc
+++ b/src/nb_http_options.cc
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2019 NEC Corporation
+ */
+
+#include "necbaas/nb_http_options.h"
+#include <curlpp/Options.hpp>
+
+namespace necbaas {
+
+NbHttpOptions &NbHttpOptions::SslCert(const std::string &val) {
+    options_[CURLOPT_SSLCERT] = std::make_shared<curlpp::Options::SslCert>(val);
+    return *this;
+}
+
+NbHttpOptions &NbHttpOptions::SslCertType(const std::string &val) {
+    options_[CURLOPT_SSLCERTTYPE] = std::make_shared<curlpp::Options::SslCertType>(val);
+    return *this;
+}
+
+NbHttpOptions &NbHttpOptions::SslCertPasswd(const std::string &val) {
+    options_[CURLOPT_SSLCERTPASSWD] = std::make_shared<curlpp::Options::SslCertPasswd>(val);
+    return *this;
+}
+
+NbHttpOptions &NbHttpOptions::SslKey(const std::string &val) {
+    options_[CURLOPT_SSLKEY] = std::make_shared<curlpp::Options::SslKey>(val);
+    return *this;
+}
+
+NbHttpOptions &NbHttpOptions::SslKeyType(const std::string &val) {
+    options_[CURLOPT_SSLKEYTYPE] = std::make_shared<curlpp::Options::SslKeyType>(val);
+    return *this;
+}
+
+NbHttpOptions &NbHttpOptions::SslKeyPasswd(const std::string &val) {
+    options_[CURLOPT_SSLKEYPASSWD] = std::make_shared<curlpp::Options::SslKeyPasswd>(val);
+    return *this;
+}
+
+NbHttpOptions &NbHttpOptions::SslVerifyPeer(bool val) {
+    options_[CURLOPT_SSL_VERIFYPEER] = std::make_shared<curlpp::Options::SslVerifyPeer>(val);
+    return *this;
+}
+
+NbHttpOptions &NbHttpOptions::CaInfo(const std::string &val) {
+    options_[CURLOPT_CAINFO] = std::make_shared<curlpp::Options::CaInfo>(val);
+    return *this;
+}
+
+NbHttpOptions &NbHttpOptions::CaPath(const std::string &val) {
+    options_[CURLOPT_CAPATH] = std::make_shared<curlpp::Options::CaPath>(val);
+    return *this;
+}
+
+std::map<CURLoption, std::shared_ptr<curlpp::OptionBase>> NbHttpOptions::GetOptions() const {
+    return options_;
+}
+
+} //namespace necbaas

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TEST_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/nb_file_bucket_test.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/nb_object_test.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/nb_object_bucket_test.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/nb_http_options_test.cc
     )
 
 add_executable(unit_test ${TEST_FILES})

--- a/unit_tests/nb_http_options_test.cc
+++ b/unit_tests/nb_http_options_test.cc
@@ -1,0 +1,67 @@
+#include "gtest/gtest.h"
+#include "test_util.h"
+#include "necbaas/nb_http_options.h"
+#include <curlpp/Options.hpp>
+
+#define CURLOPT_GETVAL(optp, type) \
+    dynamic_cast<curlpp::Options::type *>(optp)->getValue()
+
+namespace necbaas {
+
+TEST(NbHttpOptions, Empty) {
+    auto opts = NbHttpOptions();
+    EXPECT_TRUE(TestUtil::NbHttpOptions_GetOptions(opts).empty());
+}
+
+TEST(NbHttpOptions, SetOptions) {
+    auto opts = NbHttpOptions()
+        .SslCert("/path/to/cert.pem")
+        .SslCertType("PEM")
+        .SslCertPasswd("certpasswd")
+        .SslKey("/path/to/key.pem")
+        .SslKeyPasswd("keypasswd")
+        .SslVerifyPeer(true)
+        .CaInfo("/path/to/cacert.pem")
+        .CaPath("/path/to/ca");
+
+    auto map = TestUtil::NbHttpOptions_GetOptions(opts);
+    // SSLCERTPASSWD and SSLKEYPASSWD is the same thing.
+    EXPECT_EQ(map.size(), 7);
+
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLCERT].get(), SslCert), "/path/to/cert.pem");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLCERTTYPE].get(), SslCertType), "PEM");
+    // SSLCERTPASSWD is overridden.
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLCERTPASSWD].get(), SslCertPasswd), "keypasswd");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLKEY].get(), SslKey), "/path/to/key.pem");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLKEYTYPE].get(), SslKeyType), "PEM");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLKEYPASSWD].get(), SslKeyPasswd), "keypasswd");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSL_VERIFYPEER].get(), SslVerifyPeer), true);
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_CAINFO].get(), CaInfo), "/path/to/cacert.pem");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_CAPATH].get(), CaPath), "/path/to/ca");
+}
+
+TEST(NbHttpOptions, OptionOverride) {
+    auto opts = NbHttpOptions()
+        .SslCert("/path/to/cert.pem")
+        .SslCertType("PEM")
+        .SslCertPasswd("certpasswd");
+
+    auto map = TestUtil::NbHttpOptions_GetOptions(opts);
+    EXPECT_EQ(map.size(), 3);
+
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLCERT].get(), SslCert), "/path/to/cert.pem");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLCERTTYPE].get(), SslCertType), "PEM");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLCERTPASSWD].get(), SslCertPasswd), "certpasswd");
+
+    opts.SslCert("/new/path/to/cert.der")
+        .SslCertType("DER");
+
+    map = TestUtil::NbHttpOptions_GetOptions(opts);
+    EXPECT_EQ(map.size(), 3);
+
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLCERT].get(), SslCert), "/new/path/to/cert.pem");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLCERTTYPE].get(), SslCertType), "DER");
+    EXPECT_EQ(CURLOPT_GETVAL(map[CURLOPT_SSLCERTPASSWD].get(), SslCertPasswd), "certpasswd");
+}
+
+} //namespace necbaas

--- a/unit_tests/nb_http_request_factory_test.cc
+++ b/unit_tests/nb_http_request_factory_test.cc
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 #include "necbaas/internal/nb_http_request_factory.h"
+#include <curlpp/Options.hpp>
 
 namespace necbaas {
 
@@ -15,6 +16,8 @@ const string kPath{"apiPath"};
 const string kBody{"body"};
 
 const string kEmpty{""};
+
+const NbHttpOptions kOpts = NbHttpOptions().SslCert("cert.pem");
 
 string MakeUrl(const string &end_point_url, const string &tenant_id, const string &path, const string &url_params) {
     return end_point_url + "1/" + tenant_id + path + url_params;
@@ -59,7 +62,7 @@ std::multimap<std::string, std::string> GetHeaders(const std::list<string> &head
 //ヘッダ追加：なし
 //ボディ：なし
 TEST(NbHttpRequestFactory, Get) {
-    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kSessionToken, kProxy);
+    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kSessionToken, kProxy, kOpts);
 
     EXPECT_FALSE(factory.IsError());
     
@@ -75,6 +78,8 @@ TEST(NbHttpRequestFactory, Get) {
     EXPECT_EQ("baas embedded sdk", headers.find("User-Agent")->second);
     EXPECT_TRUE(request.GetBody().empty());
     EXPECT_EQ(kProxy, request.GetProxy());
+    EXPECT_EQ(1, request.GetHttpOptions().size());
+    EXPECT_EQ("cert.pem", dynamic_cast<curlpp::Options::SslCert *>(request.GetHttpOptions().front().get())->getValue());
 }
 
 //NbHttpRequestFactory Put
@@ -89,7 +94,7 @@ TEST(NbHttpRequestFactory, Get) {
 //ヘッダ追加：なし
 //ボディ：あり
 TEST(NbHttpRequestFactory, Put) {
-    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kEmpty, kEmpty);
+    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kEmpty, kEmpty, kOpts);
 
     EXPECT_FALSE(factory.IsError());
 
@@ -116,6 +121,8 @@ TEST(NbHttpRequestFactory, Put) {
     EXPECT_EQ("abcdef", headers.find("X-HEADER-KEY")->second);
     EXPECT_EQ(kBody, request.GetBody());
     EXPECT_EQ(kEmpty, request.GetProxy());
+    EXPECT_EQ(1, request.GetHttpOptions().size());
+    EXPECT_EQ("cert.pem", dynamic_cast<curlpp::Options::SslCert *>(request.GetHttpOptions().front().get())->getValue());
 }
 
 //NbHttpRequestFactory Post
@@ -130,7 +137,7 @@ TEST(NbHttpRequestFactory, Put) {
 //ヘッダ追加：あり
 //ボディ：あり
 TEST(NbHttpRequestFactory, Post) {
-    NbHttpRequestFactory factory(kEndPointUrl + "/", kTenantId, kAppId, kAppKey, kSessionToken, kEmpty);
+    NbHttpRequestFactory factory(kEndPointUrl + "/", kTenantId, kAppId, kAppKey, kSessionToken, kEmpty, kOpts);
 
     EXPECT_FALSE(factory.IsError());
 
@@ -153,6 +160,8 @@ TEST(NbHttpRequestFactory, Post) {
     EXPECT_EQ("abcdef", headers.find("X-HEADER-KEY")->second);
     EXPECT_EQ(kBody, request.GetBody());
     EXPECT_EQ(kEmpty, request.GetProxy());
+    EXPECT_EQ(1, request.GetHttpOptions().size());
+    EXPECT_EQ("cert.pem", dynamic_cast<curlpp::Options::SslCert *>(request.GetHttpOptions().front().get())->getValue());
 }
 
 //NbHttpRequestFactory Delete
@@ -167,7 +176,7 @@ TEST(NbHttpRequestFactory, Post) {
 //ヘッダ追加：あり（Key重複）
 //ボディ：あり
 TEST(NbHttpRequestFactory, Delete) {
-    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kSessionToken, kEmpty);
+    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kSessionToken, kEmpty, kOpts);
 
     EXPECT_FALSE(factory.IsError());
 
@@ -204,6 +213,8 @@ TEST(NbHttpRequestFactory, Delete) {
     EXPECT_EQ("key-2-2", iterator->second);
     EXPECT_EQ(kBody, request.GetBody());
     EXPECT_EQ(kEmpty, request.GetProxy());
+    EXPECT_EQ(1, request.GetHttpOptions().size());
+    EXPECT_EQ("cert.pem", dynamic_cast<curlpp::Options::SslCert *>(request.GetHttpOptions().front().get())->getValue());
 }
 
 //NbHttpRequestFactory
@@ -212,7 +223,7 @@ TEST(NbHttpRequestFactory, Delete) {
 //ヘッダ：あり（Key or Valueが空文字）
 //ヘッダ追加：あり（Key or Valueが空文字）
 TEST(NbHttpRequestFactory, EmptyParam) {
-    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kSessionToken, kEmpty);
+    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kSessionToken, kEmpty, kOpts);
 
     EXPECT_FALSE(factory.IsError());
 
@@ -244,11 +255,13 @@ TEST(NbHttpRequestFactory, EmptyParam) {
     EXPECT_EQ("baas embedded sdk", headers.find("User-Agent")->second);
     EXPECT_EQ(kBody, request.GetBody());
     EXPECT_EQ(kEmpty, request.GetProxy());
+    EXPECT_EQ(1, request.GetHttpOptions().size());
+    EXPECT_EQ("cert.pem", dynamic_cast<curlpp::Options::SslCert *>(request.GetHttpOptions().front().get())->getValue());
 }
 
 //NbHttpRequestFactory User-Agent ヘッダあり
 TEST(NbHttpRequestFactory, UserAgent) {
-    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kEmpty, kEmpty);
+    NbHttpRequestFactory factory(kEndPointUrl, kTenantId, kAppId, kAppKey, kEmpty, kEmpty, kOpts);
 
     EXPECT_FALSE(factory.IsError());
 
@@ -274,26 +287,28 @@ TEST(NbHttpRequestFactory, UserAgent) {
     EXPECT_EQ("test user agent", headers.find("User-Agent")->second);
     EXPECT_EQ(kBody, request.GetBody());
     EXPECT_EQ(kEmpty, request.GetProxy());
+    EXPECT_EQ(1, request.GetHttpOptions().size());
+    EXPECT_EQ("cert.pem", dynamic_cast<curlpp::Options::SslCert *>(request.GetHttpOptions().front().get())->getValue());
 }
 
 //NbHttpRequestFactory IsError
 TEST(NbHttpRequestFactory, IsError) {
-    NbHttpRequestFactory *factory = new NbHttpRequestFactory(kEmpty, kTenantId, kAppId, kAppKey, kSessionToken, kProxy);
+    NbHttpRequestFactory *factory = new NbHttpRequestFactory(kEmpty, kTenantId, kAppId, kAppKey, kSessionToken, kProxy, kOpts);
     EXPECT_TRUE(factory->IsError());
     EXPECT_EQ(NbResultCode::NB_ERROR_ENDPOINT_URL, factory->GetError());
     delete factory;
 
-    factory = new NbHttpRequestFactory(kEndPointUrl, kEmpty, kAppId, kAppKey, kSessionToken, kProxy);
+    factory = new NbHttpRequestFactory(kEndPointUrl, kEmpty, kAppId, kAppKey, kSessionToken, kProxy, kOpts);
     EXPECT_TRUE(factory->IsError());
     EXPECT_EQ(NbResultCode::NB_ERROR_TENANT_ID, factory->GetError());
     delete factory;
 
-    factory = new NbHttpRequestFactory(kEndPointUrl, kTenantId, kEmpty, kAppKey, kSessionToken, kProxy);
+    factory = new NbHttpRequestFactory(kEndPointUrl, kTenantId, kEmpty, kAppKey, kSessionToken, kProxy, kOpts);
     EXPECT_TRUE(factory->IsError());
     EXPECT_EQ(NbResultCode::NB_ERROR_APP_ID, factory->GetError());
     delete factory;
 
-    factory = new NbHttpRequestFactory(kEndPointUrl, kTenantId, kAppId, kEmpty, kSessionToken, kProxy);
+    factory = new NbHttpRequestFactory(kEndPointUrl, kTenantId, kAppId, kEmpty, kSessionToken, kProxy, kOpts);
     EXPECT_TRUE(factory->IsError());
     EXPECT_EQ(NbResultCode::NB_ERROR_APP_KEY, factory->GetError());
     delete factory;

--- a/unit_tests/nb_http_request_test.cc
+++ b/unit_tests/nb_http_request_test.cc
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "necbaas/internal/nb_http_request.h"
 #include "necbaas/internal/nb_logger.h"
+#include <curlpp/Options.hpp>
 
 namespace necbaas {
 
@@ -18,8 +19,9 @@ TEST(NbHttpRequest, DumpDisable) {
     headers.push_back("X-HEADER-KEY2: 123456");
 
     string body{"message body"};
+    NbHttpOptions opts;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty, opts);
 
     NbLogger::SetRestLogEnabled(false);
 
@@ -27,6 +29,48 @@ TEST(NbHttpRequest, DumpDisable) {
     request.Dump();
     string out_string = testing::internal::GetCapturedStdout();
     EXPECT_EQ(kEmpty, out_string);
+}
+
+TEST(NbHttpRequest, GetHttpOptionsNone) {
+    std::list<string> headers;
+
+    string body{"message body"};
+    NbHttpOptions opts;
+
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty, opts);
+
+    std::list<std::shared_ptr<curlpp::OptionBase>> opt_list = request.GetHttpOptions();
+    EXPECT_TRUE(opt_list.empty());
+}
+
+TEST(NbHttpRequest, GetHttpOptionsSome) {
+    std::list<string> headers;
+
+    string body{"message body"};
+    NbHttpOptions opts;
+    opts.SslCert("/tmp/cert.pem")
+        .SslCertType("PEM")
+        .SslCertPasswd("passwd");
+
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty, opts);
+
+    std::list<std::shared_ptr<curlpp::OptionBase>> opt_list = request.GetHttpOptions();
+    EXPECT_EQ(opt_list.size(), 3);
+    auto iter = std::find_if(opt_list.begin(), opt_list.end(), [](std::shared_ptr<curlpp::OptionBase> &x) {
+        auto *p = dynamic_cast<curlpp::Options::SslCert *>(x.get());
+        return p != nullptr && p->getValue() == "/tmp/cert.pem";
+    });
+    EXPECT_NE(iter, opt_list.end());
+    iter = std::find_if(opt_list.begin(), opt_list.end(), [](std::shared_ptr<curlpp::OptionBase> &x) {
+        auto *p = dynamic_cast<curlpp::Options::SslCertType *>(x.get());
+        return p != nullptr && p->getValue() == "PEM";
+    });
+    EXPECT_NE(iter, opt_list.end());
+    iter = std::find_if(opt_list.begin(), opt_list.end(), [](std::shared_ptr<curlpp::OptionBase> &x) {
+        auto *p = dynamic_cast<curlpp::Options::SslCertPasswd *>(x.get());
+        return p != nullptr && p->getValue() == "passwd";
+    });
+    EXPECT_NE(iter, opt_list.end());
 }
 
 static int CountString(const string &str, const string &search) {
@@ -46,8 +90,9 @@ TEST(NbHttpRequest, DumpHeaderNone) {
     std::list<string> headers;
 
     string body{"message body"};
+    NbHttpOptions opts;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty, opts);
 
     NbLogger::SetRestLogEnabled(true);
 
@@ -68,8 +113,9 @@ TEST(NbHttpRequest, DumpApplicationJson) {
     headers.push_back("Content-Type: application/json");
 
     string body{"message body"};
+    NbHttpOptions opts;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty, opts);
 
     NbLogger::SetRestLogEnabled(true);
 
@@ -90,8 +136,9 @@ TEST(NbHttpRequest, DumpTextPlain) {
     headers.push_back("X-HEADER-KEY2: 123456");
 
     string body{"message body"};
+    NbHttpOptions opts;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty, opts);
 
     NbLogger::SetRestLogEnabled(true);
 
@@ -112,8 +159,9 @@ TEST(NbHttpRequest, DumpTextHtml) {
     headers.push_back("X-HEADER-KEY2: 123456");
 
     string body{"message body"};
+    NbHttpOptions opts;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty, opts);
 
     NbLogger::SetRestLogEnabled(true);
 
@@ -132,8 +180,9 @@ TEST(NbHttpRequest, DumpTextXml) {
     headers.push_back("Content-Type: text/xml");
 
     string body{"message body"};
+    NbHttpOptions opts;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty, opts);
 
     NbLogger::SetRestLogEnabled(true);
 
@@ -154,8 +203,9 @@ TEST(NbHttpRequest, DumpImageJpeg) {
     headers.push_back("Content-Type: image/jpeg");
 
     string body{"message body"};
+    NbHttpOptions opts;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, headers, body, kEmpty, opts);
 
     NbLogger::SetRestLogEnabled(true);
 

--- a/unit_tests/nb_rest_executor_test.cc
+++ b/unit_tests/nb_rest_executor_test.cc
@@ -19,6 +19,9 @@ static const vector<string> kRespHeaders = {
 static const char kBody[] = "1234567890abcdefghij";
 static const string kProxy{"https://proxy.com/proxy:8080"};
 
+static const NbHttpOptions kEmptyOpts;
+static const NbHttpOptions kOpts = NbHttpOptions().SslCert("cert.pem");
+
 static string MakeFilePath(string file_name) {
     string file_path = __FILE__;
     file_path.erase(file_path.rfind("/") + 1);
@@ -166,11 +169,11 @@ static void CheckCurlOption(const NbRestExecutorTest &executor, const NbHttpRequ
     EXPECT_EQ(request.GetHeaders(), headers.getValue());
 }
 
-//NbRestExecutor::ExecuteRequest(GET, bodyなし、Proxyなし、タイムアウトデフォルト)
+//NbRestExecutor::ExecuteRequest(GET, bodyなし、Proxyなし、HTTPオプションなし、タイムアウトデフォルト)
 TEST(NbRestExecutor, ExecuteRequestGet) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -178,11 +181,11 @@ TEST(NbRestExecutor, ExecuteRequestGet) {
     CheckCurlOption(executor, request);
 }
 
-//NbRestExecutor::ExecuteRequest(GET, bodyあり、Proxyあり、タイムアウト0)
+//NbRestExecutor::ExecuteRequest(GET, bodyあり、Proxyあり、HTTPオプションあり、タイムアウト0)
 TEST(NbRestExecutor, ExecuteRequestGet2) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kBody, kProxy);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kBody, kProxy, kOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request, 0);
 
@@ -194,7 +197,7 @@ TEST(NbRestExecutor, ExecuteRequestGet2) {
 TEST(NbRestExecutor, ExecuteRequestPut1) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request, -1);
 
@@ -207,7 +210,7 @@ TEST(NbRestExecutor, ExecuteRequestPut2) {
     NbLogger::SetDebugLogEnabled(true);
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kBody, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kBody, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -220,7 +223,7 @@ TEST(NbRestExecutor, ExecuteRequestPost1) {
     NbLogger::SetDebugLogEnabled(false);
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_POST, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_POST, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -232,7 +235,7 @@ TEST(NbRestExecutor, ExecuteRequestPost1) {
 TEST(NbRestExecutor, ExecuteRequestPost2) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_POST, kReqHeaders, kBody, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_POST, kReqHeaders, kBody, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -244,7 +247,7 @@ TEST(NbRestExecutor, ExecuteRequestPost2) {
 TEST(NbRestExecutor, ExecuteRequestDelete1) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_DELETE, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_DELETE, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -256,7 +259,7 @@ TEST(NbRestExecutor, ExecuteRequestDelete1) {
 TEST(NbRestExecutor, ExecuteRequestDelete2) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_DELETE, kReqHeaders, kBody, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_DELETE, kReqHeaders, kBody, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -274,7 +277,7 @@ TEST(NbRestExecutor, ExecuteRequestStatuCodeNone) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -293,7 +296,7 @@ TEST(NbRestExecutor, ExecuteRequestStatusCode299) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -312,7 +315,7 @@ TEST(NbRestExecutor, ExecuteRequestStatusCode300) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -327,7 +330,7 @@ TEST(NbRestExecutor, ExecuteRequestLibcurlRuntimeError) {
     NbRestExecutorTest executor;
     executor.error_trigger_ = NbResultCode::NB_ERROR_CURL_RUNTIME;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -350,7 +353,7 @@ TEST(NbRestExecutor, ExecuteRequestLibcurlRuntimeError400) {
 
     executor.response_body_ = (char *)"{\"error\":\"File size over\"}";
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -372,7 +375,7 @@ TEST(NbRestExecutor, ExecuteRequestLibcurlRuntimeError100) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -393,7 +396,7 @@ TEST(NbRestExecutor, ExecuteRequestLibcurlRuntimeError299) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -416,7 +419,7 @@ TEST(NbRestExecutor, ExecuteRequestLibcurlRuntimeError300) {
 
     executor.response_body_ = (char *)"{\"error\":\"File size over\"}";
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -430,7 +433,7 @@ TEST(NbRestExecutor, ExecuteRequestLibcurlLogicError) {
     NbRestExecutorTest executor;
     executor.error_trigger_ = NbResultCode::NB_ERROR_CURL_LOGIC;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -443,7 +446,7 @@ TEST(NbRestExecutor, ExecuteRequestException) {
     NbRestExecutorTest executor;
     executor.error_trigger_ = NbResultCode::NB_ERROR_CURL_FATAL;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteRequest(request);
 
@@ -505,7 +508,7 @@ static void CheckCurlOptionUpload(const NbRestExecutorTest &executor, const NbHt
 TEST(NbRestExecutor, ExecuteFileUploadPut) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"));
 
@@ -517,7 +520,7 @@ TEST(NbRestExecutor, ExecuteFileUploadPut) {
 TEST(NbRestExecutor, ExecuteFileUploadPost) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_POST, kReqHeaders, kEmpty, kProxy);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_POST, kReqHeaders, kEmpty, kProxy, kOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"), 10);
 
@@ -529,7 +532,7 @@ TEST(NbRestExecutor, ExecuteFileUploadPost) {
 TEST(NbRestExecutor, ExecuteFileUploadGet) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"));
 
@@ -541,7 +544,7 @@ TEST(NbRestExecutor, ExecuteFileUploadGet) {
 TEST(NbRestExecutor, ExecuteFileUploadFileOpenError) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, kEmpty);
 
@@ -554,7 +557,7 @@ TEST(NbRestExecutor, ExecuteFileUploadLibcurlRuntimeError) {
     NbRestExecutorTest executor;
     executor.error_trigger_ = NbResultCode::NB_ERROR_CURL_RUNTIME;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"));
 
@@ -577,7 +580,7 @@ TEST(NbRestExecutor, ExecuteFileUploadLibcurlRuntimeError400) {
 
     executor.response_body_ = (char *)"{\"error\":\"File size over\"}";
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"));
 
@@ -599,7 +602,7 @@ TEST(NbRestExecutor, ExecuteFileUploadLibcurlRuntimeError100) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"));
 
@@ -621,7 +624,7 @@ TEST(NbRestExecutor, ExecuteFileUploadLibcurlRuntimeError299) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"));
 
@@ -644,7 +647,7 @@ TEST(NbRestExecutor, ExecuteFileUploadLibcurlRuntimeError300) {
 
     executor.response_body_ = (char *)"{\"error\":\"File size over\"}";
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"));
 
@@ -658,7 +661,7 @@ TEST(NbRestExecutor, ExecuteFileUploadLibcurlLogicError) {
     NbRestExecutorTest executor;
     executor.error_trigger_ = NbResultCode::NB_ERROR_CURL_LOGIC;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"));
 
@@ -671,7 +674,7 @@ TEST(NbRestExecutor, ExecuteFileUploadException) {
     NbRestExecutorTest executor;
     executor.error_trigger_ = NbResultCode::NB_ERROR_CURL_FATAL;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileUpload(request, MakeFilePath("upload.dat"));
 
@@ -704,7 +707,7 @@ class NbRestExecutorDownloadTest : public ::testing::Test {
 TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownload) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -716,7 +719,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownload) {
 TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownload2) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kProxy);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kProxy, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"), 10);
 
@@ -728,7 +731,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownload2) {
 TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadInvalidMethod) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_PUT, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -747,7 +750,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadXContentLengthNone) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -766,7 +769,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadLengthError) {
         "X-Content-Length: 30\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -778,7 +781,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadLengthError) {
 TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadFileOpenError) {
     NbRestExecutorTest executor;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, kEmpty);
 
@@ -791,7 +794,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadLibcurlRuntimeError) {
     NbRestExecutorTest executor;
     executor.error_trigger_ = NbResultCode::NB_ERROR_CURL_RUNTIME;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -814,7 +817,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadLibcurlRuntimeError400) {
 
     executor.response_body_ = (char *)"{\"error\":\"File size over\"}";
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -836,7 +839,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadLibcurlRuntimeError200) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -857,7 +860,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadLibcurlRuntimeError299) {
         "Content-Length: 20\r\n",
         "\r\n"};
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -880,7 +883,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadLibcurlRuntimeError300) {
 
     executor.response_body_ = (char *)"{\"error\":\"File size over\"}";
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -894,7 +897,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadLibcurlLogicError) {
     NbRestExecutorTest executor;
     executor.error_trigger_ = NbResultCode::NB_ERROR_CURL_LOGIC;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 
@@ -907,7 +910,7 @@ TEST_F(NbRestExecutorDownloadTest, ExecuteFileDownloadException) {
     NbRestExecutorTest executor;
     executor.error_trigger_ = NbResultCode::NB_ERROR_CURL_FATAL;
 
-    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty);
+    NbHttpRequest request(kUrl, NbHttpRequestMethod::HTTP_REQUEST_TYPE_GET, kReqHeaders, kEmpty, kEmpty, kEmptyOpts);
 
     NbResult<NbHttpResponse> result = executor.ExecuteFileDownload(request, string("download.dat"));
 

--- a/unit_tests/test_util.h
+++ b/unit_tests/test_util.h
@@ -2,6 +2,7 @@
 #define NECBAAS_TESTUTIL_H
 
 #include "necbaas/internal/nb_http_request_factory.h"
+#include "necbaas/nb_http_options.h"
 
 namespace necbaas {
 // テストユーティリティクラス
@@ -31,6 +32,10 @@ class TestUtil {
 
     static const std::string &NbHttpRequestFactory_GetProxy(const NbHttpRequestFactory &factory) {
         return factory.proxy_;
+    }
+
+    static const std::map<CURLoption, std::shared_ptr<curlpp::OptionBase>> NbHttpOptions_GetOptions(const NbHttpOptions &options) {
+        return options.GetOptions();
     }
 };
 }//namespace necbaas


### PR DESCRIPTION
SDK で libcurl の SSL 関連オプションを指定する I/F を追加しました。
UT, FT 込みです。

FT はクライアント認証を設定したサーバーが必要なため、通常の FT 用のエンドポイントと別でパラメータ指定するようにしています。
また、SSL 関連項目は *SslTest でフィルターできるようにしています。
